### PR TITLE
Added config drive and user data for hcs on prem

### DIFF
--- a/huaweicloudstack/sdk/huaweicloud/openstack/ecs/v1/cloudservers/requests.go
+++ b/huaweicloudstack/sdk/huaweicloud/openstack/ecs/v1/cloudservers/requests.go
@@ -15,7 +15,7 @@ type CreateOpts struct {
 
 	Name string `json:"name" required:"true"`
 
-	UserData []byte `json:"-"`
+	UserData         []byte             `json:"user_data,omitempty"`
 
 	// AdminPass sets the root user password. If not set, a randomly-generated
 	// password will be created and returned in the response.
@@ -78,6 +78,7 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 			userData = string(opts.UserData)
 		}
 		b["user_data"] = &userData
+		b["config_drive"] = true
 	}
 
 	return map[string]interface{}{"server": b}, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

I noticed that when using hcs provider with our on premise hcs8.3 installation the VM would create but no network, hostname or any other injected data was there. We do not use DHCP for configuration of network and rely on config_drive.

Making the json for user data more strict and adding back the config drive = true fixed this for me. 

It should not break anyone using metadata service as this will override the cloud drive.

Sorry for bad english

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-hcs/huaweicloud       70.796s
```
