### PR TITLE
fix(cce): fix JSON unmarshalling error for cluster conditions

### DIFF
--- a/huaweicloudstack/sdk/huaweicloud/openstack/cce/v3/clusters/results.go
+++ b/huaweicloudstack/sdk/huaweicloud/openstack/cce/v3/clusters/results.go
@@ -140,12 +140,12 @@ type Status struct {
 	//Reasons for the cluster to become current
 	Reason string `json:"reason"`
 	//The status of each component in the cluster
-	Conditions Conditions `json:"conditions"`
+	Conditions []Condition `json:"conditions"`
 	//Kube-apiserver access address in the cluster
 	Endpoints []Endpoints `json:"-"`
 }
 
-type Conditions struct {
+type Condition struct {
 	//The type of component
 	Type string `json:"type"`
 	//The state of the component


### PR DESCRIPTION
The CCE API returns 'conditions' as an array, but the struct defined it as a single object, causing Terraform to crash with: 'cannot unmarshal array into Go struct field Clusters.status.tmp.conditions'

### Description
This PR fixes a critical JSON unmarshalling panic when reading CCE cluster status.

### Problem
The CCE API returns `status.conditions` as a JSON array:
```json
"conditions": [
  {
    "type": "ClusterCertificate",
    "status": "False",
    "reason": "CertificateValid"
  }
]
However, the Go struct Status defined Conditions as a single object struct instead of a slice ([]Conditions), causing the following error:
error waiting for CCE cluster to be available: json: cannot unmarshal array into Go struct field Clusters.status.tmp.conditions of type clusters.Conditions

Solution
Updated the Conditions field in Status struct to be a slice: []Conditions